### PR TITLE
Add options to specify block/element/modifier selector templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,6 +615,31 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@babel/preset-react": "^7.9.4",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
-    "rollup": "^2.8.2"
+    "rollup": "^2.8.2",
+    "lodash.template": "^4.5.0"
   },
   "repository": {
     "type": "git",

--- a/src/bem.js
+++ b/src/bem.js
@@ -1,5 +1,8 @@
-export const BEM = (block) => (elem, mods) => {
-  let base = `.${block}`;
+export const BEM = (block) => (elem, mods, options) => {
+  const template = require('lodash.template');
+  let data = { block };
+  let formatter = template(options.blockFormat);
+  let base = formatter(data);
 
   if (!elem) {
     return base;
@@ -11,7 +14,9 @@ export const BEM = (block) => (elem, mods) => {
   }
 
   if (elem !== '') {
-    base = `.${block}__${elem}`;
+    data = { block, elem };
+    formatter = template(options.elementFormat);
+    base = formatter(data);
   }
 
   return (mods ? Object.entries(mods).reduce((target, [key, value]) => {
@@ -19,7 +24,9 @@ export const BEM = (block) => (elem, mods) => {
       return target;
     }
 
-    target += `${value === true ? (`${base}_${key}`) : (`${base}_${key}_${value}`)}`;
+    data = { base, key, value };
+    formatter = value === true ? template(options.modifierFormatTrue) : template(options.modifierFormat);
+    target += formatter(data);
 
     return target;
   }, '') : base);

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,11 @@ const DEFAULT_OPTIONS = {
   component: 'component',
   element: 'elem',
   modifier: 'mod',
-  modifierRegExp: /([\w\-]+)(?:\[([\w\-]+)\])?/
+  modifierRegExp: /([\w\-]+)(?:\[([\w\-]+)\])?/,
+  blockFormat: '.${block}',
+  elementFormat: '.${block}__${elem}',
+  modifierFormat: '${base}_${key}_${value}',
+  modifierFormatTrue: '${base}_${key}'
 };
 
 export default postcss.plugin('postcss-bike', (options = DEFAULT_OPTIONS) => {
@@ -25,7 +29,7 @@ export default postcss.plugin('postcss-bike', (options = DEFAULT_OPTIONS) => {
 
       switch (node.metadata.type) {
         case options.component:
-          selector = node.metadata.bem();
+          selector = node.metadata.bem(null, null, options);
           break;
         case options.modifier:
           let [, modName, modVal = true] = node.metadata.name.match(options.modifierRegExp);
@@ -33,18 +37,18 @@ export default postcss.plugin('postcss-bike', (options = DEFAULT_OPTIONS) => {
           node.metadata.mods = { [modName]: modVal };
 
           if (node.parent.metadata.type === options.element) {
-            selector = node.metadata.bem(node.parent.metadata.name, { [modName]: modVal });
+            selector = node.metadata.bem(node.parent.metadata.name, { [modName]: modVal }, options);
           } else if (node.parent.metadata.type === options.modifier) {
-            selector = node.metadata.bem({ ...node.parent.metadata.mods, [modName]: modVal });
+            selector = node.metadata.bem({ ...node.parent.metadata.mods, [modName]: modVal }, null, options);
           } else {
-            selector = node.metadata.bem({ [modName]: modVal });
+            selector = node.metadata.bem({ [modName]: modVal }, null, options);
           }
           break;
         case options.element:
           if (node.parent.metadata.type === options.modifier) {
-            selector = [node.parent.selector, node.metadata.bem(node.metadata.name)].join(' ');
+            selector = [node.parent.selector, node.metadata.bem(node.metadata.name, null, options)].join(' ');
           } else {
-            selector = node.metadata.bem(node.metadata.name);
+            selector = node.metadata.bem(node.metadata.name, null, options);
           }
           break;
       }


### PR DESCRIPTION
I needed this for a project with non-BEM classes and thought it would be handy to use the Bike plugin with options to specify the template of the selectors for block/element/modifiers, using template strings/string literals.

Not sure of any security implications of using lodash.template which I think runs eval() on the template?

The templates can be specified in the options as:

`{
  blockFormat: '.${block}',
  elementFormat: '.${block}__${elem}',
  modifierFormat: '${base}_${key}_${value}',
  modifierFormatTrue: '${base}_${key}'
}`

Since this project is BEM-focused then this functionality might not really be needed or suitable but thought I'd leave this here for any interested people.