### PR TITLE
Feature/multiple modifier values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ postcss([bike()]).process(css).then((res) => console.log(output.css));
     }
   }
 
+  @mod theme[foo|bar] {
+    @elem header {
+      position: absolute;
+    }
+  }
+  
   @elem header {
     flex: 0 0 50px;
     background-color: #fff;
@@ -89,6 +95,10 @@ Transformed to:
 .example_theme_dark .example__footer {
   background-color: #1b1b1b;
   color: #fff;
+}
+.example_theme_foo .example__header,
+.example_theme_bar .example__header {
+  position: absolute;
 }
 .example__header {
   flex: 0 0 50px;
@@ -134,10 +144,11 @@ Allows to set custom name for modifier `@rule`.
 ### `modifierRegExp`
 
 type: `RegExp`  
-default: `{modifierRegExp: /(\w+)\[(\w+)\]/}`
+default: `{modifierRegExp: /(\w+)\[(\w+)| \]/}`
 
 Allows to set custom regular expressions for modifier params. Where `$1` is Modifier Name and `$2` is Modifier Value. For 
 changing Modifier Value Separator, change default separator `\[$2\]`, which goes before and after `$2` (only this `[ ]` symbols).
+Multiple values (used as 'OR') can be separated with a vertical pipe (`|`).
 
 
 ### License [MIT](LICENSE)

--- a/src/bem.js
+++ b/src/bem.js
@@ -5,22 +5,29 @@ export const BEM = (block) => (elem, mods) => {
     return base;
   }
 
+  // Handle multiple bases e.g. comma-separated elements.
+  let bases = [base];
+
   if (typeof elem === 'object') {
     mods = elem;
     elem = '';
   }
 
   if (elem !== '') {
-    base = `.${block}__${elem}`;
+    bases = elem.split(',').map(elem => {
+      return `.${block}__${elem.trim()}`;
+    });
   }
 
-  return (mods ? Object.entries(mods).reduce((target, [key, value]) => {
-    if (!value) {
+  return bases.map(base => {
+    return mods ? Object.entries(mods).reduce((target, [key, value]) => {
+      if (!value) {
+        return target;
+      }
+
+      target += `${value === true ? (`${base}_${key}`) : (`${base}_${key}_${value}`)}`;
+
       return target;
-    }
-
-    target += `${value === true ? (`${base}_${key}`) : (`${base}_${key}_${value}`)}`;
-
-    return target;
-  }, '') : base);
+    }, '') : base;
+  }).join(', ');
 };


### PR DESCRIPTION
This branch fixes generating selectors for:
* multiple elements e.g. @elem foo, bar {}
* multiple modifier names e.g. @mod foo, bar {}
* multiple modifier values e.g. @mod theme[foo|bar] {} (NB pipe-delimited to apply as 'OR', i.e. ..--theme_foo, ..--theme_bar {}